### PR TITLE
Pin contributions workflow

### DIFF
--- a/.github/workflows/pause-community-contributions.yml
+++ b/.github/workflows/pause-community-contributions.yml
@@ -16,6 +16,6 @@ permissions:
 jobs:
   pause:
     if: github.repository_owner == 'exercism' # Stops this job from running on forks
-    uses: exercism/github-actions/.github/workflows/community-contributions.yml@community-contributions-reuseable-workflow
+    uses: exercism/github-actions/.github/workflows/community-contributions.yml@3390a06eae3295d427e35adfc15c0bf5d7f32973
     with:
       forum_category: fsharp

--- a/.github/workflows/pause-community-contributions.yml
+++ b/.github/workflows/pause-community-contributions.yml
@@ -16,6 +16,6 @@ permissions:
 jobs:
   pause:
     if: github.repository_owner == 'exercism' # Stops this job from running on forks
-    uses: exercism/github-actions/.github/workflows/community-contributions.yml@3390a06eae3295d427e35adfc15c0bf5d7f32973
+    uses: exercism/github-actions/.github/workflows/community-contributions.yml@main
     with:
       forum_category: fsharp


### PR DESCRIPTION
Pin the pause community contributions workflow to a specific commit
rather than a branch name.
